### PR TITLE
Fail image scan when CVEs are found

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -63,6 +63,7 @@ jobs:
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          exit-code: ${{ github.event_name == 'schedule'  && '1' || '0' }}
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -56,7 +56,7 @@ jobs:
           PLUGINS_NEXUS_PASSWORD: ${{ secrets.PLUGINS_NEXUS_PASSWORD }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.9.0
+        uses: aquasecurity/trivy-action@0.9.1
         with:
           image-ref: 'coremedia/headless-server-commerce:${{ github.sha }}'
           format: 'template'


### PR DESCRIPTION
The Trivy image scan action should terminate with an error when CVE are found. But it should not fail for PRs (or feature branches) when the CVEs already exist on the base branch.