### PR TITLE
Update Spring Boot and CMS (main)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
   build:
     name: Build with Maven
     runs-on: ubuntu-latest
+    env:
+      PLUGINS_NEXUS_USER: ${{ secrets.PLUGINS_NEXUS_USER }}
+      PLUGINS_NEXUS_PASSWORD: ${{ secrets.PLUGINS_NEXUS_PASSWORD }}
 
     steps:
       - name: Checkout repository
@@ -41,9 +44,6 @@ jobs:
               install javadoc:javadoc \
               -Pintegration-test,default-image,docs-third-party \
               -Dsort.verifyFail=stop
-        env:
-          PLUGINS_NEXUS_USER: ${{ secrets.PLUGINS_NEXUS_USER }}
-          PLUGINS_NEXUS_PASSWORD: ${{ secrets.PLUGINS_NEXUS_PASSWORD }}
 
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive.
       - name: Update dependency graph

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 ### Hidden (My) Files ###
+
+/tmp/
+
 ### Use for example for user properties. ###
 
 .my.*

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -21,7 +21,10 @@ Build the workspace with
 
 Run the server with
 
-    mvn spring-boot:run -pl headless-server-commerce-app -Dspring-boot.run.profiles=local,preview -Dinstallation.host=<CMS-SERVER-HOSTNAME>
+    mvn spring-boot:run \
+        -pl headless-server-commerce-app \
+        -Dspring-boot.run.profiles=dev,local \
+        -Dspring-boot.run.jvmArguments="-Dinstallation.host=<CMS-SERVER-HOSTNAME>"
 
 or specify a profile defining the required property `installation.server.host`
 . All prepared spring boot profiles can be

--- a/headless-server-commerce-app/pom.xml
+++ b/headless-server-commerce-app/pom.xml
@@ -88,6 +88,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/headless-server-commerce-app/src/main/java/com/coremedia/blueprint/boot/headlessserver/HeadlessServerCommerceApp.java
+++ b/headless-server-commerce-app/src/main/java/com/coremedia/blueprint/boot/headlessserver/HeadlessServerCommerceApp.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 import static java.lang.invoke.MethodHandles.lookup;
 
@@ -18,8 +19,9 @@ import static java.lang.invoke.MethodHandles.lookup;
         "net.devh.boot.grpc.client.autoconfigure.GrpcClientHealthAutoConfiguration",
         "net.devh.boot.grpc.client.autoconfigure.GrpcClientMetricAutoConfiguration",
         "com.coremedia.blueprint.caas.p13n.P13nAutoConfiguration",
-        "com.coremedia.caas.web.CaasWebAutoConfiguration", // use CommerceCaasAutoConfiguration instead
+        "com.coremedia.caas.web.CaasWebAutoConfiguration", // excluded in favour of CommerceCaasAutoConfiguration
 })
+@ComponentScan("com.coremedia.cap.undoc.common.spring") // required because component loader in not active here
 public class HeadlessServerCommerceApp {
 
   private static final Logger LOG = LoggerFactory.getLogger(lookup().lookupClass());

--- a/headless-server-commerce-app/src/main/java/com/coremedia/blueprint/boot/headlessserver/HeadlessServerCommerceApp.java
+++ b/headless-server-commerce-app/src/main/java/com/coremedia/blueprint/boot/headlessserver/HeadlessServerCommerceApp.java
@@ -18,6 +18,7 @@ import static java.lang.invoke.MethodHandles.lookup;
         "net.devh.boot.grpc.client.autoconfigure.GrpcClientHealthAutoConfiguration",
         "net.devh.boot.grpc.client.autoconfigure.GrpcClientMetricAutoConfiguration",
         "com.coremedia.blueprint.caas.p13n.P13nAutoConfiguration",
+        "com.coremedia.caas.web.CaasWebAutoConfiguration", // use CommerceCaasAutoConfiguration instead
 })
 public class HeadlessServerCommerceApp {
 

--- a/headless-server-commerce-app/src/test/java/com/coremedia/blueprint/boot/headlessserver/HeadlessServerCommerceAppIT.java
+++ b/headless-server-commerce-app/src/test/java/com/coremedia/blueprint/boot/headlessserver/HeadlessServerCommerceAppIT.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(properties = {
         "repository.factoryClassName=com.coremedia.cap.xmlrepo.XmlCapConnectionFactory",
         "com.coremedia.transform.blobCache.basePath=${user.dir}/target/blobCache",
+        "caas.search.enabled=false",
 })
 @SuppressWarnings("SpringBootApplicationProperties")
 class HeadlessServerCommerceAppIT {

--- a/headless-server-commerce-base-lib/pom.xml
+++ b/headless-server-commerce-base-lib/pom.xml
@@ -39,6 +39,10 @@
     </dependency>
     <dependency>
       <groupId>com.coremedia.cms</groupId>
+      <artifactId>common.plugin-framework-autoconfiguration</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.coremedia.cms</groupId>
       <artifactId>coremedia-common</artifactId>
     </dependency>
     <dependency>

--- a/headless-server-commerce-base-lib/src/main/resources/META-INF/spring.factories
+++ b/headless-server-commerce-base-lib/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.coremedia.blueprint.headlessserver.CaasConfig

--- a/headless-server-commerce-base-lib/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/headless-server-commerce-base-lib/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.coremedia.blueprint.headlessserver.CommerceCaasAutoConfiguration

--- a/headless-server-commerce-lib/pom.xml
+++ b/headless-server-commerce-lib/pom.xml
@@ -74,6 +74,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/headless-server-commerce-lib/src/main/java/com/coremedia/blueprint/caas/labs/CommerceLabsAutoConfiguration.java
+++ b/headless-server-commerce-lib/src/main/java/com/coremedia/blueprint/caas/labs/CommerceLabsAutoConfiguration.java
@@ -17,19 +17,15 @@ import com.coremedia.livecontext.ecommerce.common.BaseCommerceBeanType;
 import com.coremedia.livecontext.ecommerce.common.CommerceBean;
 import com.coremedia.livecontext.ecommerce.common.CommerceBeanType;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-@Configuration(proxyBeanMethods = false)
-@Import({
-        BaseCommerceServicesAutoConfiguration.class
-})
-public class CommerceLabsConfig {
+@AutoConfiguration(after = BaseCommerceServicesAutoConfiguration.class)
+public class CommerceLabsAutoConfiguration {
 
   private static final Set<String> SCHEMA_TYPE_NAMES = Set.of(
           CommerceBean.class.getSimpleName(),

--- a/headless-server-commerce-lib/src/main/resources/META-INF/spring.factories
+++ b/headless-server-commerce-lib/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.coremedia.blueprint.caas.labs.CommerceLabsConfig

--- a/headless-server-commerce-lib/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/headless-server-commerce-lib/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.coremedia.blueprint.caas.labs.CommerceLabsAutoConfiguration

--- a/headless-server-commerce-parent/pom.xml
+++ b/headless-server-commerce-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.5</version>
+    <version>2.7.9</version>
     <relativePath/>
   </parent>
 

--- a/headless-server-commerce-parent/pom.xml
+++ b/headless-server-commerce-parent/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <cms.version>2201.1</cms.version>
+    <cms.version>2301.1</cms.version>
     <springfox.version>3.0.0</springfox.version>
     <graphiql-spring-boot-starter.version>11.1.0</graphiql-spring-boot-starter.version>
     <caffeine.version>2.9.3</caffeine.version>


### PR DESCRIPTION
autoclose none

MediaController can no longer be used without blueprint. Broke with https://github.com/CoreMedia/cms/pull/26813. Let's exclude MediaController and friends.