### PR TITLE
Bump SolrJ from 8.11.2 to 9.3.0 (main)

### DIFF
--- a/headless-server-commerce-parent/pom.xml
+++ b/headless-server-commerce-parent/pom.xml
@@ -48,6 +48,7 @@
     <netty.version>4.1.96.Final</netty.version>
     <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
     <snakeyaml.version>2.1</snakeyaml.version>
+    <solr.version>9.3.0</solr.version>
     <spring-framework.version>5.3.29</spring-framework.version>
 
     <!-- versions managed in com.coremedia.cms BOMs (overwrites) -->
@@ -182,6 +183,21 @@
         <groupId>net.sourceforge.htmlcleaner</groupId>
         <artifactId>htmlcleaner</artifactId>
         <version>${htmlcleaner.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.solr</groupId>
+        <artifactId>solr-solrj</artifactId>
+        <version>${solr.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.solr</groupId>
+        <artifactId>solr-solrj-streaming</artifactId>
+        <version>${solr.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.solr</groupId>
+        <artifactId>solr-solrj-zookeeper</artifactId>
+        <version>${solr.version}</version>
       </dependency>
       <dependency>
         <!-- Only a transitive dependency, but must be managed to mitigate CVEs -->

--- a/headless-server-commerce-parent/pom.xml
+++ b/headless-server-commerce-parent/pom.xml
@@ -179,12 +179,6 @@
         <scope>runtime</scope>
       </dependency>
       <dependency>
-        <!-- Only a transitive dependency, but must be managed to mitigate CVEs -->
-        <groupId>org.json</groupId>
-        <artifactId>json</artifactId>
-        <version>${json.version}</version>
-      </dependency>
-      <dependency>
         <groupId>net.sourceforge.htmlcleaner</groupId>
         <artifactId>htmlcleaner</artifactId>
         <version>${htmlcleaner.version}</version>
@@ -194,6 +188,12 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <!-- Only a transitive dependency, but must be managed to mitigate CVEs -->
+        <groupId>org.json</groupId>
+        <artifactId>json</artifactId>
+        <version>${json.version}</version>
       </dependency>
       <dependency>
         <groupId>org.yaml</groupId>


### PR DESCRIPTION
With CMS 2307.1, SolrJ has been updated from 8.11.2 to 9.2.1. As the Spring Boot Parent still manages the Solr versions to 8.11.2, we must update the management for this project to Solr 9.2.1, using the same property `solr.version` in order to prevent dependency conflicts. It should be safe to even go with the latest minor version. And we can now rely on Dependabot updates instead of having to manually update SolrJ after each and every CMS update.