### PR TITLE
Group CodeQL Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       interval: monthly
       time: '00:27'
       timezone: 'Etc/UTC'
+    groups:
+      github-codeql-action:
+        patterns:
+          - 'github/codeql-action*'
     labels:
       - dependencies
       - ginger


### PR DESCRIPTION
Group GitHub CodeQL action updates so Dependabot opens one pull request for the sub-actions instead of one per action.